### PR TITLE
Implemented warning for missing O4O token

### DIFF
--- a/dac-spa/src/App.vue
+++ b/dac-spa/src/App.vue
@@ -81,8 +81,10 @@
         <v-btn @click="logout">Logout</v-btn>
       </div>
     </v-app-bar>
+
     <v-main>
-      <router-view />
+      <ServiceMsg ref="serviceMsg"/>
+      <router-view  v-on:service-msg="onServiceMessage"/>
     </v-main>
   </v-app>
 </template>
@@ -90,6 +92,7 @@
 <script>
 import md5 from "md5";
 import AuthJS from "@okta/okta-auth-js";
+import ServiceMsg from "@/components/ServiceMsg";
 
 export default {
   name: "App",
@@ -120,7 +123,7 @@ export default {
       suItems: [
         { title: this.$t("home"), icon: "mdi-home-city", route: "/" },
         { title: this.$t("tenants"), icon: "mdi-domain", route: "tenants" },
-      ],
+      ]
     };
   },
   computed: {
@@ -164,6 +167,9 @@ export default {
   async created() {
     await this.isAuthenticated();
   },
+  components: {
+    ServiceMsg
+  },
   watch: {
     // Everytime the route changes, check for auth status
     $route: "isAuthenticated",
@@ -190,6 +196,9 @@ export default {
       this.$router.push({
         name: "home",
       });
+    },
+    onServiceMessage(e){
+      this.$refs.serviceMsg.onServiceMessage(e)
     },
     async logout() {
       await this.$auth.logout();

--- a/dac-spa/src/components/ServiceMsg.vue
+++ b/dac-spa/src/components/ServiceMsg.vue
@@ -1,0 +1,29 @@
+<template>
+    <v-banner ref="banner" single-line color="error"  v-model="display">
+        <v-icon slot="icon" color="white">mdi-alert-octagon</v-icon>
+        <span class="font-weight-light">{{ message }}</span>
+        <template v-slot:actions="{ dismiss }">
+            <v-btn text color="white" @click="dismiss">Dismiss</v-btn>
+        </template>
+    </v-banner>
+</template>
+
+<script>
+
+export default {
+    name: 'service-msg',
+    data() {
+        return {
+            message: '',
+            display: false
+        }
+    },
+
+    methods: {
+        onServiceMessage(e){
+            this.message = e  
+            this.display = true
+        }
+    }
+}
+</script>

--- a/dac-spa/src/plugins/i18n.js
+++ b/dac-spa/src/plugins/i18n.js
@@ -10,7 +10,10 @@ const messages = {
     tenant: "Tenant",
     tenants: "Tenants",
     users: "Users",
-    settings: "Settings"
+    settings: "Settings",
+    errors: {
+      unableToGetSession: "Could not access Okta session to retrieve administrator access token"
+    }
   },
   es: {
     tenant: "Grupo",

--- a/dac-spa/src/views/Home.vue
+++ b/dac-spa/src/views/Home.vue
@@ -137,15 +137,20 @@ export default {
                 } catch (e) {
                     console.log(e);
                 }
-            }
-            if (this.$root.$children) {
-                if (this.$root.$children[0].superuserFlag) {
-                    this.homeCards = this.suCards;
+                if (this.$root.$children) {
+                    if (this.$root.$children[0].superuserFlag) {
+                        this.homeCards = this.suCards;
+                    } else {
+                        this.homeCards = this.tenantAdminCards;
+                    }
                 } else {
-                    this.homeCards = this.tenantAdminCards;
+                    this.homeCards = this.noCards;
                 }
-            } else {
-                this.homeCards = this.noCards;
+            }
+            else{
+                //no o4o token available, hide functionality
+                this.homeCards = this.homeCards = this.noCards;
+                this.$emit('service-msg',this.$t("errors.unableToGetSession"))
             }
         },
         route(route) {


### PR DESCRIPTION
As discussed in #9 Chrome 83 prevents 3rd party cookie access in incognito, this silently broke the session check for retrieving access tokens for O4O.

Added generic ServiceMsg component displaying warning banner.
Child components can emit service-msg to display this message.
Added emit to home where no session can be retrieved.
Added I18n error message for condition.