### PR TITLE
Correcting OktaAuth redirectUri paramater and fixing activation

### DIFF
--- a/dac-spa/src/components/Activate.vue
+++ b/dac-spa/src/components/Activate.vue
@@ -160,9 +160,12 @@ export default {
             password: this.password,
           })
           .then(function(transaction) {
-            self.$auth.loginRedirect("/", {
-              sessionToken: transaction.sessionToken,
-            });
+            if (transaction.status === 'SUCCESS') {
+              self.$auth.session.setCookieAndRedirect(transaction.sessionToken,"/");
+            }
+            else {
+              console.error('We cannot handle the ' + transaction.status + ' status');
+            }
           })
           .catch(function(err) {
             console.error(err);

--- a/dac-spa/src/router/index.js
+++ b/dac-spa/src/router/index.js
@@ -107,8 +107,7 @@ config.oidc.redirect_uri =
 const oktaAuth = new OktaAuth({
   issuer: config.oidc.issuer,
   clientId: config.oidc.client_id,
-  client_id: config.oidc.client_id,
-  redirect_uri: config.oidc.redirect_uri,
+  redirectUri: config.oidc.redirect_uri,
   scopes: config.oidc.scope.split(" "),
   pkce: true,
   onSessionExpired: function() {


### PR DESCRIPTION
Typo on the redirect uri param results in default behaviour sending user to non-whitelisted root page.